### PR TITLE
networkmanager hook for url logging

### DIFF
--- a/webkit2png.py
+++ b/webkit2png.py
@@ -196,6 +196,7 @@ class _WebkitRendererHelper(QObject):
         self.connect(self._page, SIGNAL("loadFinished(bool)"), self._on_load_finished)
         self.connect(self._page, SIGNAL("loadStarted()"), self._on_load_started)
         self.connect(self._page.networkAccessManager(), SIGNAL("sslErrors(QNetworkReply *,const QList<QSslError>&)"), self._on_ssl_errors)
+        self.connect(self._page.networkAccessManager(), SIGNAL("finished(QNetworkReply *)"), self._on_each_reply)
 
         # The way we will use this, it seems to be unesseccary to have Scrollbars enabled
         self._page.mainFrame().setScrollBarPolicy(Qt.Horizontal, Qt.ScrollBarAlwaysOff)
@@ -305,6 +306,10 @@ class _WebkitRendererHelper(QObject):
             if self.scaleRatio == 'crop':
                 qImage = qImage.copy(0, 0, self.scaleToWidth, self.scaleToHeight)
         return qImage
+
+    def _on_each_reply(self,reply):
+      """Logs each requested uri"""
+      logger.debug("Received %s" % (reply.url().toString()))
 
     # Eventhandler for "loadStarted()" signal
     def _on_load_started(self):


### PR DESCRIPTION
I've added a debug callback to print each url used to render a specific page.
My use case was to count the number of different hosts required to render www.cnn.com or www.apple.com.
After a bit of processing the output looks like:

www.apple.com showed up 2 times.
images.apple.com showed up 32 times.
c2c738.r.axf8.net showed up 1 time.
fls.doubleclick.net showed up 1 time.
metrics.apple.com showed up 3 times.
ad.doubleclick.net showed up 2 times.
ad.br.doubleclick.net showed up 1 time.

cheers
