### PR TITLE
Added option for treating URL as url-encoded

### DIFF
--- a/scripts/webkit2png
+++ b/scripts/webkit2png
@@ -113,6 +113,8 @@ if __name__ == '__main__':
                       help="Render output on a transparent background (Be sure to have a transparent background defined in the html)", default=False)
     parser.add_option("", "--style", dest="style",
                       help="Change the Qt look and feel to STYLE (e.G. 'windows').", metavar="STYLE")
+    parser.add_option("", "--encoded-url", dest="encoded_url", action="store_true",
+        help="Treat URL as url-encoded", metavar="ENCODED_URL", default=False)
     parser.add_option("-d", "--display", dest="display",
                       help="Connect to X server at DISPLAY.", metavar="DISPLAY")
     parser.add_option("--debug", action="store_true", dest="debug",
@@ -181,6 +183,7 @@ if __name__ == '__main__':
             renderer.format = options.format
             renderer.grabWholeWindow = options.window
             renderer.renderTransparentBackground = options.transparent
+            renderer.encodedUrl = options.encoded_url
 
             if options.scale:
                 renderer.scaleRatio = options.ratio

--- a/webkit2png/webkit2png.py
+++ b/webkit2png/webkit2png.py
@@ -114,6 +114,7 @@ sys.exit(app.exec_())
         self.ignoreConfirm = kwargs.get('ignoreConfirm', True)
         self.ignorePrompt = kwargs.get('ignorePrompt', True)
         self.interruptJavaScript = kwargs.get('interruptJavaScript', True)
+        self.encodedUrl = kwargs.get('encodedUrl', False)
 
         # Set some default options for QWebPage
         self.qWebSettings = {
@@ -264,10 +265,10 @@ class _WebkitRendererHelper(QObject):
         cancelAt = time.time() + timeout
         self.__loading = True
         self.__loadingResult = False # Default
-        # TODO: fromEncoded() needs to be used in some situations.  Some
-        # sort of flag should be passed in to WebkitRenderer maybe?
-        #self._page.mainFrame().load(QUrl.fromEncoded(url))
-        self._page.mainFrame().load(QUrl(url))
+        if self.encodedUrl:
+            self._page.mainFrame().load(QUrl.fromEncoded(url))
+        else:
+            self._page.mainFrame().load(QUrl(url))
         while self.__loading:
             if timeout > 0 and time.time() >= cancelAt:
                 raise RuntimeError("Request timed out on %s" % url)


### PR DESCRIPTION
By default is set to False to provide previous behavior.
It seems that QUrl.fromEncoded() doesn't break straightforward URLs and fix urlencoded (e.g. cyrillic values in URL - www.google.com/search?q=тест).
So it makes sense to enable it by default.
