### PR TITLE
Allow loading HTML code instead of an URL

### DIFF
--- a/webkit2png/webkit2png.py
+++ b/webkit2png/webkit2png.py
@@ -257,9 +257,9 @@ class _WebkitRendererHelper(QObject):
             url = res
 
         if self.encodedUrl:
-            qtUrl = QUrl.fromEncoded(res)
+            qtUrl = QUrl.fromEncoded(url)
         else:
-            qtUrl = QUrl(res)
+            qtUrl = QUrl(url)
 
         # Set the required cookies, if any
         self.cookieJar = CookieJar(self.cookies, qtUrl)
@@ -267,7 +267,7 @@ class _WebkitRendererHelper(QObject):
 
         # Load the page
         if type(res) == tuple:
-            self._page.mainFrame().setHtml(res[0], res[1]) # HTML, baseUrl
+            self._page.mainFrame().setHtml(res[0], qtUrl) # HTML, baseUrl
         else:
             self._page.mainFrame().load(qtUrl)
 


### PR DESCRIPTION
With this change you can now directly put HTML code into the library
which will then be rendered and a image will be taken of.

The methods render(), render_to_file() and render_to_bytes() do allow
either a string, which is used as URL to be fetched, like before and
as new alternative, a tuple as first parameter. The tuple needs to be
made of two strings, the first one is HTML code which is loaded into
webkit, the second one is a URL which is used as base URL for the
loaded HTML code which will be used to resolve relative URLs in the
HTML code.
