### PR TITLE
add sleep to decrease cpu usage while waiting for response

### DIFF
--- a/webkit2png/webkit2png.py
+++ b/webkit2png/webkit2png.py
@@ -295,6 +295,8 @@ class _WebkitRendererHelper(QObject):
                 raise RuntimeError("Request timed out on %s" % res)
             while QApplication.hasPendingEvents() and self.__loading:
                 QCoreApplication.processEvents()
+            # sleep to decrease cpu usage while waiting for response
+            time.sleep(0.5)
 
         if self.logger: self.logger.debug("Processing result")
 


### PR DESCRIPTION
**before:**
$ `time webkit2png --xvfb 1024 1024 -g 1024 1024 --scale 200 200 --aspect-ratio=keep --timeout=30 --log='' -o /tmp/img.png http://long-site`
real    0m10.553s
user    0m8.383s
sys 0m2.092s

**after:**
$ `time webkit2png --xvfb 1024 1024 -g 1024 1024 --scale 200 200 --aspect-ratio=keep --timeout=30 --log='' -o /tmp/img.png http://long-site`
real    0m11.074s
user    0m0.412s
sys 0m0.078s
